### PR TITLE
[TouchableBounce] Add import for Platform

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -14,6 +14,7 @@
 var Animated = require('Animated');
 var EdgeInsetsPropType = require('EdgeInsetsPropType');
 var NativeMethodsMixin = require('react/lib/NativeMethodsMixin');
+var Platform = require('Platform');
 var React = require('React');
 var Touchable = require('Touchable');
 


### PR DESCRIPTION
When attempting to add flow to my project, I encountered this.
```
node_modules/react-native/Libraries/Components/Touchable/TouchableBounce.js:91
 91:       useNativeDriver: Platform.OS === 'android',
                            ^^^^^^^^ identifier `Platform`. Could not resolve name
```