### PR TITLE
support hermes for our RCTCxxBridge patch

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -408,7 +408,7 @@ struct RCTInstanceCallback : public InstanceCallback {
       if(strcmp(returnType, @encode(void *)) == 0) {
         // `jsExecutorFactoryForBridge` returns `void *`
         id<RCTCxxBridgeDelegate> cxxDelegate = (id<RCTCxxBridgeDelegate>)self.delegate;
-        executorFactory = std::make_shared<JSCExecutorFactory>(*reinterpret_cast<JSCExecutorFactory *>([cxxDelegate jsExecutorFactoryForBridge:self]));
+        executorFactory.reset(reinterpret_cast<JSExecutorFactory *>([cxxDelegate jsExecutorFactoryForBridge:self]));
       } else {
         // `jsExecutorFactoryForBridge` returns `std::unique_ptr<JSExecutorFactory>`
         id<RCTCxxBridgeTurboModuleDelegate> cxxDelegate = (id<RCTCxxBridgeTurboModuleDelegate>)self.delegate;


### PR DESCRIPTION
# Why

our patch code assumed to use `JSCExecutorFactory` and not support hermes.

# How

use `JSExecutorFactory` instead.
since `std::make_shared` cannot work with abstract class, use `std::shared_ptr<T>::reset` instead.

# Test Plan

- [x] bare-expo + jsc
- [x] bare-expo + hermes
- [x] expo-go (jsc)