### PR TITLE
Remove JS changes from our fork

### DIFF
--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -76,7 +76,7 @@ function reportException(
       e.jsEngine == null ? message : `${message}, js engine: ${e.jsEngine}`;
 
     const isHandledByLogBox =
-      e.forceRedbox !== true && __DEV__ && !global.RN$Bridgeless && !global.RN$Express;
+      e.forceRedbox !== true && !global.RN$Bridgeless && !global.RN$Express;
 
     const data = preprocessException({
       message,

--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -190,24 +190,13 @@ const AppRegistry = {
         () => msg,
       );
     }
-
-    // NOTE(brentvatne): the original error message here, commented out below,
-    // is not useful to developers in the Expo managed workflow. It also will
-    // prevent any red box error that has occurred while loading the bundle from
-    // being visible to the user. So, we instead warn and give a more tailored
-    // message to help users with debugging the issue.
-    if (!runnables[appKey] || !runnables[appKey].run) {
-      console.warn(`Unable to start your application. Please refer to https://expo.fyi/no-registered-application for more information.`);
-      return;
-    }
-
-    // invariant(
-    //   runnables[appKey] && runnables[appKey].run,
-    //   `"${appKey}" has not been registered. This can happen if:\n` +
-    //     '* Metro (the local dev server) is run from the wrong folder. ' +
-    //     'Check if Metro is running, stop it and restart it in the current project.\n' +
-    //     "* A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called.",
-    // );
+    invariant(
+      runnables[appKey] && runnables[appKey].run,
+      `"${appKey}" has not been registered. This can happen if:\n` +
+        '* Metro (the local dev server) is run from the wrong folder. ' +
+        'Check if Metro is running, stop it and restart it in the current project.\n' +
+        "* A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called.",
+    );
 
     SceneTracker.setActiveScene({name: appKey});
     runnables[appKey].run(appParameters);

--- a/Libraries/Text/Text/NSTextStorage+FontScaling.m
+++ b/Libraries/Text/Text/NSTextStorage+FontScaling.m
@@ -7,6 +7,8 @@
 
 #import "NSTextStorage+FontScaling.h"
 
+#import <React/RCTLog.h>
+
 typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
   RCTTextSizeComparisonSmaller     = 1 << 0,
   RCTTextSizeComparisonLarger      = 1 << 1,
@@ -125,9 +127,14 @@ typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
 
       CGFloat fontSize = MAX(MIN(font.pointSize * ratio, maximumFontSize), minimumFontSize);
 
-      [self addAttribute:NSFontAttributeName
-                   value:[font fontWithSize:fontSize]
-                   range:range];
+      UIFont *scaledFont = [font fontWithSize:fontSize];
+      if (scaledFont) {
+        [self addAttribute:NSFontAttributeName
+                    value:scaledFont
+                    range:range];
+      } else {
+        RCTLogError(@"Font \"%@"" doesn't support automatic scaling.", font.familyName);
+      }
     }
   ];
 

--- a/Libraries/Text/Text/NSTextStorage+FontScaling.m
+++ b/Libraries/Text/Text/NSTextStorage+FontScaling.m
@@ -7,8 +7,6 @@
 
 #import "NSTextStorage+FontScaling.h"
 
-#import <React/RCTLog.h>
-
 typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
   RCTTextSizeComparisonSmaller     = 1 << 0,
   RCTTextSizeComparisonLarger      = 1 << 1,
@@ -127,14 +125,9 @@ typedef NS_OPTIONS(NSInteger, RCTTextSizeComparisonOptions) {
 
       CGFloat fontSize = MAX(MIN(font.pointSize * ratio, maximumFontSize), minimumFontSize);
 
-      UIFont *scaledFont = [font fontWithSize:fontSize];
-      if (scaledFont) {
-        [self addAttribute:NSFontAttributeName
-                    value:scaledFont
-                    range:range];
-      } else {
-        RCTLogError(@"Font \"%@"" doesn't support automatic scaling.", font.familyName);
-      }
+      [self addAttribute:NSFontAttributeName
+                   value:[font fontWithSize:fontSize]
+                   range:range];
     }
   ];
 

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -34,47 +34,10 @@ if (NativeAppearance) {
           colorScheme == null,
         "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
       );
-      // Update cached value
-      preferences.colorScheme = colorScheme;
       eventEmitter.emit('change', {colorScheme});
     },
   );
 }
-
-function getInitialColorScheme(): ?ColorSchemeName {
-  if (__DEV__) {
-    if (isAsyncDebugging) {
-      // Hard code light theme when using the async debugger as
-      // sync calls aren't supported
-      return 'light';
-    }
-  }
-
-  // TODO: (hramos) T52919652 Use ?ColorSchemeName once codegen supports union
-  const nativeColorScheme: ?string =
-    NativeAppearance == null ? null : NativeAppearance.getColorScheme() || null;
-  invariant(
-    nativeColorScheme === 'dark' ||
-      nativeColorScheme === 'light' ||
-      nativeColorScheme == null,
-    "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
-  );
-  return nativeColorScheme;
-}
-
-function getColorScheme(): ?ColorSchemeName {
-  if (!preferences.colorScheme) {
-    const initialColorScheme = getInitialColorScheme();
-    preferences.colorScheme = initialColorScheme;
-    return preferences.colorScheme;
-  }
-
-  return preferences.colorScheme;
-}
-
-const preferences = {
-  colorScheme: null,
-};
 
 module.exports = {
   /**
@@ -87,7 +50,28 @@ module.exports = {
    *
    * @returns {?ColorSchemeName} Value for the color scheme preference.
    */
-  getColorScheme,
+  getColorScheme(): ?ColorSchemeName {
+    if (__DEV__) {
+      if (isAsyncDebugging) {
+        // Hard code light theme when using the async debugger as
+        // sync calls aren't supported
+        return 'light';
+      }
+    }
+
+    // TODO: (hramos) T52919652 Use ?ColorSchemeName once codegen supports union
+    const nativeColorScheme: ?string =
+      NativeAppearance == null
+        ? null
+        : NativeAppearance.getColorScheme() || null;
+    invariant(
+      nativeColorScheme === 'dark' ||
+        nativeColorScheme === 'light' ||
+        nativeColorScheme == null,
+      "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
+    );
+    return nativeColorScheme;
+  },
   /**
    * Add an event handler that is fired when appearance preferences change.
    */


### PR DESCRIPTION
# Why

remove expo forked react-native dependency from managed workflow project.
close [ENG-1900](https://linear.app/expo/issue/ENG-1900/remove-forked-react-native-for-managed-apps)

# How

1. list ours changes: `git log Libraries/`. there are thress commits:
- a80b16c7a0233a46a1eb82fbe274344489312670
- 625e44d0d622b940b9adada1f3b4a5e808ad2338
- 42f556cde800d124d03cc9e7c2fa605edf24916c

2. revert each of them

# Test Plan

- bare-expo
- expo-go
- for eas-build with managed project, we didn't adopt our forked react-native. supposedly apps should still work fine even not adopting these changes. let's monitor if there are any regression issues after removing these js changes.
