### PR TITLE
Fix codegen resolution error when node_modules has different version

### DIFF
--- a/scripts/generate-specs-cli.js
+++ b/scripts/generate-specs-cli.js
@@ -11,7 +11,8 @@
 
 let RNCodegen;
 try {
-  RNCodegen = require('react-native-codegen/lib/generators/RNCodegen.js');
+  // Use the `react-native-codegen` from the `react-native` repository instead of node_modules.
+  RNCodegen = require(__dirname + '/../packages/react-native-codegen/lib/generators/RNCodegen.js');
 } catch (e) {
   RNCodegen = require('../packages/react-native-codegen/lib/generators/RNCodegen.js');
   if (!RNCodegen) {

--- a/scripts/generate-specs.sh
+++ b/scripts/generate-specs.sh
@@ -62,7 +62,8 @@ main() {
     exit 1
   fi
 
-  CODEGEN_PATH=$("$NODE_BINARY" -e "console.log(require('path').dirname(require.resolve('react-native-codegen/package.json')))")
+  # Use the `react-native-codegen` from the `react-native` repository instead of node_modules.
+  CODEGEN_PATH="$RN_DIR/packages/react-native-codegen"
 
   # Special case for running CodeGen from source: build it
   if [ ! -d "$CODEGEN_PATH/lib" ]; then


### PR DESCRIPTION
# Why

fix android client build error for https://github.com/expo/expo/pull/15914 when different react-native version between `node_modules/react-native` and `react-native-lab/react-native`.

# How

use the `react-native-codegen` from the same repository.