### PR TITLE
[android] fix ReactRootView cast error happening on stripe sdk

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -14,6 +14,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.graphics.Canvas;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -919,6 +920,14 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
+    private Activity getActivity() {
+      Context context = getContext();
+      while (!(context instanceof Activity) && context instanceof ContextWrapper) {
+        context = ((ContextWrapper) context).getBaseContext();
+      }
+      return (Activity) context;
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.M)
     private void checkForKeyboardEvents() {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
@@ -934,7 +943,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           Insets barInsets = compatRootInsets.getInsets(WindowInsetsCompat.Type.systemBars());
           int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode = ((Activity) getContext()).getWindow().getAttributes().softInputMode;
+          int softInputMode = getActivity().getWindow().getAttributes().softInputMode;
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height


### PR DESCRIPTION
# Why

when testing stripe sdk example "Card element only" test case, there is an exception from keyboard listener

```
         AndroidRuntime  D  Shutting down VM
                         E  FATAL EXCEPTION: main
                         E  Process: host.exp.exponent, PID: 8849
                         E  java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:937)
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:913)
                         E      at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1061)
                         E      at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3352)
                         E      at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2286)
                         E      at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8948)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1231)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
                         E      at android.view.Choreographer.doCallbacks(Choreographer.java:899)
                         E      at android.view.Choreographer.doFrame(Choreographer.java:832)
                         E      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
                         E      at android.os.Handler.handleCallback(Handler.java:942)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at android.os.Looper.loopOnce(Looper.java:201)
                         E      at android.os.Looper.loop(Looper.java:288)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7898)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

# How

the `getContext()` is actually a `ContextThemeWrapper` for `ExperienceActivity`, we should not cast it to Activity directly. this pr tries to use `getBaseContext()` to unwrap it.