### PR TITLE
[android] Fix keyboard crash when casting android.app.Activity

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -917,16 +917,13 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       checkForDeviceDimensionsChanges();
     }
 
+    @Nullable
     private Activity getActivity() {
       Context context = getContext();
       while (!(context instanceof Activity) && context instanceof ContextWrapper) {
         context = ((ContextWrapper) context).getBaseContext();
       }
-      if(context instanceof Activity){
-        return (Activity) context;
-      }
-
-      return null;
+      return (context instanceof Activity) ? (Activity) context : null;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.R)
@@ -947,7 +944,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           int height = imeInsets.bottom - barInsets.bottom;
 
           Activity activity = getActivity();
-          if(activity == null){
+          if (activity == null) {
             return;
           }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -922,7 +922,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       while (!(context instanceof Activity) && context instanceof ContextWrapper) {
         context = ((ContextWrapper) context).getBaseContext();
       }
-      return (Activity) context;
+      if(context instanceof Activity){
+        return (Activity) context;
+      }
+
+      return null;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.R)
@@ -942,7 +946,12 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
           int height = imeInsets.bottom - barInsets.bottom;
 
-          int softInputMode = getActivity().getWindow().getAttributes().softInputMode;
+          Activity activity = getActivity();
+          if(activity == null){
+            return;
+          }
+
+          int softInputMode = activity.getWindow().getAttributes().softInputMode;
           int screenY =
               softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
                   ? mVisibleViewArea.bottom - height


### PR DESCRIPTION
# Why

When opening the keyboard on Android on Expo Go, there is an exception from the keyboard listener. E.g. user attempts to enter a URL manually 

https://user-images.githubusercontent.com/11707729/220747589-6e6e54a3-7abc-44ac-b4a0-2ae35ac93405.mp4


```
         2023-02-22 16:57:03.985 29438-29438/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: host.exp.exponent, PID: 29438
    java.lang.ClassCastException: android.app.ContextImpl cannot be cast to android.app.Activity
        at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.getActivity(ReactRootView.java:925)
        at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:945)
        at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:911)
        at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1080)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4098)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2924)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:10513)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1108)
        at android.view.Choreographer.doCallbacks(Choreographer.java:866)
        at android.view.Choreographer.doFrame(Choreographer.java:797)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1092)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at android.app.ActivityThread.main(ActivityThread.java:8751)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

# How

Check if `context` is an instance of `Activity` before trying to cast it, thus preventing an incompatible cast. If `context` is not an instance of `Activity` just returns null 