### PR TITLE
Enable hermes debugger on all build variants

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle
@@ -228,7 +228,8 @@ android {
                 cmake {
                     arguments "-DCMAKE_BUILD_TYPE=MinSizeRel"
                     // For release builds, we don't want to enable the Hermes Debugger.
-                    arguments "-DHERMES_ENABLE_DEBUGGER=False"
+                    // For Expo Go, we have to enable debugging even on release builds.
+                    arguments "-DHERMES_ENABLE_DEBUGGER=True"
                 }
             }
         }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(hermes_executor
 target_compile_options(
         hermes_executor
         PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -DHERMES_ENABLE_DEBUGGER=1
         -std=c++20
         -fexceptions
 )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(hermesinstancejni
 target_compile_options(
         hermesinstancejni
         PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -DHERMES_ENABLE_DEBUGGER=1
         -std=c++20
         -fexceptions
 )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(rninstance
 target_compile_options(
         rninstance
         PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -DHERMES_ENABLE_DEBUGGER=1
         -std=c++20
         -fexceptions
 )

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -33,5 +33,6 @@ else()
                 hermes_executor_common
                 PRIVATE
                 -DNDEBUG
+                -DHERMES_ENABLE_DEBUGGER=1
         )
 endif()

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -26,6 +26,14 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug)
                 PRIVATE
                 -DHERMES_ENABLE_DEBUGGER=1
         )
+else()
+        # Expo Go requires debugging on release builds
+        target_compile_options(
+                hermes_inspector_modern
+                PRIVATE
+                # Expo Go requires debugging on release builds
+                -DHERMES_ENABLE_DEBUGGER=1
+        )
 endif()
 
 target_include_directories(hermes_inspector_modern PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(bridgeless
 target_compile_options(
         bridgeless
         PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        -DHERMES_ENABLE_DEBUGGER=1
         -std=c++20
         -fexceptions
 )

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -12,6 +12,9 @@ react_native_path = File.join(__dir__, "..", "..")
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
 version = package['version']
 
+# Force building Hermes from source because Expo Go requires customized Hermes build
+ENV['BUILD_FROM_SOURCE'] = 'true'
+
 source_type = hermes_source_type(version, react_native_path)
 source = podspec_source(source_type, version, react_native_path)
 

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -57,7 +57,8 @@ function configure_apple_framework {
   if [[ $BUILD_TYPE == "Debug" ]]; then
     enable_debugger="true"
   else
-    enable_debugger="false"
+    # Expo Go requires debugging on release build
+    enable_debugger="true"
   fi
   if [[ $BUILD_TYPE == "Debug" ]]; then
     # JS developers aren't VM developers.

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -10,7 +10,8 @@ release_version="$1"; shift
 hermesc_path="$1"; shift
 jsi_path="$1"; shift
 
-enable_debugger="false"
+# Expo Go requires debugging on release build
+enable_debugger="true"
 if [[ "$CONFIGURATION" == "Debug" ]]; then
   enable_debugger="true"
 fi


### PR DESCRIPTION
# Why

close ENG-11034

# How

patch react-native to set `HERMES_ENABLE_DEBUGGER` for all variants