### PR TITLE
Fix appearance changed into wrong activity

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
@@ -84,12 +84,20 @@ public class AppearanceModule extends NativeAppearanceSpec {
 
   @Override
   public void setColorScheme(String style) {
+    int nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
     if (style.equals("dark")) {
-      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+      nightMode = AppCompatDelegate.MODE_NIGHT_YES;
     } else if (style.equals("light")) {
-      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+      nightMode = AppCompatDelegate.MODE_NIGHT_NO;
     } else if (style.equals("unspecified")) {
-      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+      nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+    }
+
+    Activity activity = getCurrentActivity();
+    if (activity instanceof AppCompatActivity) {
+      ((AppCompatActivity) activity).getDelegate().setLocalNightMode(nightMode);
+    } else {
+      AppCompatDelegate.setDefaultNightMode(nightMode);
     }
   }
 


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/26556
close ENG-11171

# How

the original `AppCompatDelegate.setDefaultNightMode()` is a global setup. when changing the night mode, it will actually call HomeActivity's `onConfigurationChanged`. this pr tries to set night mode to current activity by using the `setLocalNightMode()`

# Test Plan

unversioned expo-go with repro from https://github.com/expo/expo/issues/26556