### PR TITLE
Add `extraModulesForBridge` impl to `RCTInstance`

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -298,7 +298,8 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  [RCTKeyWindow() addSubview:self.container];
+  UIWindow *window = RCTSharedApplication().delegate.window;
+  [window addSubview:self.container];
 
   _uiDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(threadUpdate:)];
   [_uiDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -298,8 +298,7 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  UIWindow *window = RCTSharedApplication().delegate.window;
-  [window addSubview:self.container];
+  [RCTKeyWindow() addSubview:self.container];
 
   _uiDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(threadUpdate:)];
   [_uiDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -181,6 +181,13 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
 #pragma mark - RCTTurboModuleManagerDelegate
 
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge {
+  if ([_appTMMDelegate respondsToSelector:@selector(extraModulesForBridge:)]) {
+    return [_appTMMDelegate extraModulesForBridge:bridge];
+  }
+  return @[];
+}
+
 - (Class)getModuleClassFromName:(const char *)name
 {
   if ([_appTMMDelegate respondsToSelector:@selector(getModuleClassFromName:)]) {


### PR DESCRIPTION
## Summary:

To load our bridge modules we need the RCTInstance to call `extraModulesForBridge` on the `RCTTurboModuleManagerDelegate` which will be our app delegate. Also, I needed to revert https://github.com/facebook/react-native/pull/43476 as it was causing the performance monitor to be added to the dev menus window instead of the app. 