### PR TITLE
Revert performance monitor change

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -298,7 +298,11 @@ RCT_EXPORT_MODULE()
 
   [self updateStats];
 
-  [RCTKeyWindow() addSubview:self.container];
+  // This change is causing the performance monitor and element inspector to be added to the dev menus UIWindow
+  // instead of the main app
+//  [RCTKeyWindow() addSubview:self.container];
+  UIWindow *window = RCTSharedApplication().delegate.window;
+  [window addSubview:self.container];
 
   _uiDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(threadUpdate:)];
   [_uiDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -300,7 +300,7 @@ RCT_EXPORT_MODULE()
 
   // This change is causing the performance monitor and element inspector to be added to the dev menus UIWindow
   // instead of the main app
-//  [RCTKeyWindow() addSubview:self.container];
+  // [RCTKeyWindow() addSubview:self.container];
   UIWindow *window = RCTSharedApplication().delegate.window;
   [window addSubview:self.container];
 


### PR DESCRIPTION
## Summary:

This PR reverts the change from https://github.com/facebook/react-native/pull/43476/, which caused the performance monitor and element inspector to be added to the dev menus window instead of the main app.