### PR TITLE
Add devSupportFactory for new arch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/FrameworkAPI.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/FrameworkAPI.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.common.annotations
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
     message =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
@@ -9,12 +9,15 @@ package com.facebook.react.devsupport
 
 import android.content.Context
 import com.facebook.react.common.SurfaceDelegateFactory
+import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager
 import com.facebook.react.devsupport.interfaces.RedBoxHandler
 import com.facebook.react.packagerconnection.RequestHandler
+import com.facebook.react.runtime.BridgelessDevSupportManager
+import com.facebook.react.runtime.ReactHostImpl
 
 /**
  * A simple factory that creates instances of [DevSupportManager] implementations. Uses reflection
@@ -23,92 +26,101 @@ import com.facebook.react.packagerconnection.RequestHandler
  */
 public class DefaultDevSupportManagerFactory : DevSupportManagerFactory {
 
-  @Deprecated(
-      "in favor of the customisable create for DevSupportManagerFactory",
-      ReplaceWith(
-          "create(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, redBoxHandler, devBundleDownloadListener, minNumShakes, customPackagerCommandHandlers, surfaceDelegateFactory, devLoadingViewManager, pausedInDebuggerOverlayManager)"))
-  public fun create(
-      applicationContext: Context,
-      reactInstanceDevHelper: ReactInstanceDevHelper,
-      packagerPathForJSBundleName: String?,
-      enableOnCreate: Boolean,
-      minNumShakes: Int
-  ): DevSupportManager {
-    return create(
-        applicationContext,
-        reactInstanceDevHelper,
-        packagerPathForJSBundleName,
-        enableOnCreate,
-        null,
-        null,
-        minNumShakes,
-        null,
-        null,
-        null,
-        null)
-  }
-
   public override fun create(
-      applicationContext: Context,
-      reactInstanceManagerHelper: ReactInstanceDevHelper,
-      packagerPathForJSBundleName: String?,
-      enableOnCreate: Boolean,
-      redBoxHandler: RedBoxHandler?,
-      devBundleDownloadListener: DevBundleDownloadListener?,
-      minNumShakes: Int,
-      customPackagerCommandHandlers: Map<String, RequestHandler>?,
-      surfaceDelegateFactory: SurfaceDelegateFactory?,
-      devLoadingViewManager: DevLoadingViewManager?,
-      pausedInDebuggerOverlayManager: PausedInDebuggerOverlayManager?
+    applicationContext: Context,
+    reactInstanceManagerHelper: ReactInstanceDevHelper,
+    packagerPathForJSBundleName: String?,
+    enableOnCreate: Boolean,
+    redBoxHandler: RedBoxHandler?,
+    devBundleDownloadListener: DevBundleDownloadListener?,
+    minNumShakes: Int,
+    customPackagerCommandHandlers: Map<String, RequestHandler>?,
+    surfaceDelegateFactory: SurfaceDelegateFactory?,
+    devLoadingViewManager: DevLoadingViewManager?,
+    pausedInDebuggerOverlayManager: PausedInDebuggerOverlayManager?
   ): DevSupportManager {
     return if (!enableOnCreate) {
       ReleaseDevSupportManager()
     } else
-        try {
-          // Developer support is enabled, we now must choose whether to return a DevSupportManager,
-          // or a more lean profiling-only PerftestDevSupportManager. We make the choice by first
-          // trying to return the full support DevSupportManager and if it fails, then just
-          // return PerftestDevSupportManager.
+      try {
+        // Developer support is enabled, we now must choose whether to return a DevSupportManager,
+        // or a more lean profiling-only PerftestDevSupportManager. We make the choice by first
+        // trying to return the full support DevSupportManager and if it fails, then just
+        // return PerftestDevSupportManager.
 
-          // ProGuard is surprisingly smart in this case and will keep a class if it detects a call
-          // to
-          // Class.forName() with a static string. So instead we generate a quasi-dynamic string to
-          // confuse it.
-          val className =
-              StringBuilder(DEVSUPPORT_IMPL_PACKAGE)
-                  .append(".")
-                  .append(DEVSUPPORT_IMPL_CLASS)
-                  .toString()
-          val devSupportManagerClass = Class.forName(className)
-          val constructor =
-              devSupportManagerClass.getConstructor(
-                  Context::class.java,
-                  ReactInstanceDevHelper::class.java,
-                  String::class.java,
-                  Boolean::class.javaPrimitiveType,
-                  RedBoxHandler::class.java,
-                  DevBundleDownloadListener::class.java,
-                  Int::class.javaPrimitiveType,
-                  MutableMap::class.java,
-                  SurfaceDelegateFactory::class.java,
-                  DevLoadingViewManager::class.java,
-                  PausedInDebuggerOverlayManager::class.java)
-          constructor.newInstance(
-              applicationContext,
-              reactInstanceManagerHelper,
-              packagerPathForJSBundleName,
-              true,
-              redBoxHandler,
-              devBundleDownloadListener,
-              minNumShakes,
-              customPackagerCommandHandlers,
-              surfaceDelegateFactory,
-              devLoadingViewManager,
-              pausedInDebuggerOverlayManager) as DevSupportManager
-        } catch (e: Exception) {
-          PerftestDevSupportManager(applicationContext)
-        }
+        // ProGuard is surprisingly smart in this case and will keep a class if it detects a call
+        // to
+        // Class.forName() with a static string. So instead we generate a quasi-dynamic string to
+        // confuse it.
+        val className =
+          StringBuilder(DEVSUPPORT_IMPL_PACKAGE)
+            .append(".")
+            .append(DEVSUPPORT_IMPL_CLASS)
+            .toString()
+        val devSupportManagerClass = Class.forName(className)
+        val constructor =
+          devSupportManagerClass.getConstructor(
+            Context::class.java,
+            ReactInstanceDevHelper::class.java,
+            String::class.java,
+            Boolean::class.javaPrimitiveType,
+            RedBoxHandler::class.java,
+            DevBundleDownloadListener::class.java,
+            Int::class.javaPrimitiveType,
+            MutableMap::class.java,
+            SurfaceDelegateFactory::class.java,
+            DevLoadingViewManager::class.java,
+            PausedInDebuggerOverlayManager::class.java)
+        constructor.newInstance(
+          applicationContext,
+          reactInstanceManagerHelper,
+          packagerPathForJSBundleName,
+          true,
+          redBoxHandler,
+          devBundleDownloadListener,
+          minNumShakes,
+          customPackagerCommandHandlers,
+          surfaceDelegateFactory,
+          devLoadingViewManager,
+          pausedInDebuggerOverlayManager) as DevSupportManager
+      } catch (e: Exception) {
+        PerftestDevSupportManager(applicationContext)
+      }
   }
+
+  @FrameworkAPI
+  override fun create(
+    reactHost: ReactHostImpl,
+    applicationContext: Context,
+    reactInstanceManagerHelper: ReactInstanceDevHelper,
+    packagerPathForJSBundleName: String?,
+    enableOnCreate: Boolean,
+    redBoxHandler: RedBoxHandler?,
+    devBundleDownloadListener: DevBundleDownloadListener?,
+    minNumShakes: Int,
+    customPackagerCommandHandlers: MutableMap<String, RequestHandler>?,
+    surfaceDelegateFactory: SurfaceDelegateFactory?,
+    devLoadingViewManager: DevLoadingViewManager?,
+    pausedInDebuggerOverlayManager: PausedInDebuggerOverlayManager?,
+    useDevSupport: Boolean
+  ): DevSupportManager =
+    if (!useDevSupport) {
+      ReleaseDevSupportManager()
+    } else {
+      BridgelessDevSupportManager(
+        reactHost,
+        applicationContext,
+        reactInstanceManagerHelper,
+        packagerPathForJSBundleName,
+        enableOnCreate,
+        redBoxHandler,
+        devBundleDownloadListener,
+        minNumShakes,
+        customPackagerCommandHandlers,
+        surfaceDelegateFactory,
+        devLoadingViewManager,
+        pausedInDebuggerOverlayManager)
+    }
 
   private companion object {
     private const val DEVSUPPORT_IMPL_PACKAGE = "com.facebook.react.devsupport"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
@@ -16,19 +16,43 @@ import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
+import com.facebook.react.runtime.ReactHostImpl;
 import java.util.Map;
 
 public interface DevSupportManagerFactory {
+  /**
+   * Factory used by the Old Architecture flow to create a {@link DevSupportManager} and a {@link
+   * com.facebook.react.runtime.BridgeDevSupportManager}
+   */
   DevSupportManager create(
-      Context applicationContext,
-      ReactInstanceDevHelper reactInstanceManagerHelper,
-      @Nullable String packagerPathForJSBundleName,
-      boolean enableOnCreate,
-      @Nullable RedBoxHandler redBoxHandler,
-      @Nullable DevBundleDownloadListener devBundleDownloadListener,
-      int minNumShakes,
-      @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
-      @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
-      @Nullable DevLoadingViewManager devLoadingViewManager,
-      @Nullable PausedInDebuggerOverlayManager pausedInDebuggerOverlayManager);
+    Context applicationContext,
+    ReactInstanceDevHelper reactInstanceManagerHelper,
+    @Nullable String packagerPathForJSBundleName,
+    boolean enableOnCreate,
+    @Nullable RedBoxHandler redBoxHandler,
+    @Nullable DevBundleDownloadListener devBundleDownloadListener,
+    int minNumShakes,
+    @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
+    @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+    @Nullable DevLoadingViewManager devLoadingViewManager,
+    @Nullable PausedInDebuggerOverlayManager pausedInDebuggerOverlayManager);
+
+  /**
+   * Factory used by the New Architecture/Bridgeless flow to create a {@link DevSupportManager} and
+   * a {@link com.facebook.react.runtime.BridgelessDevSupportManager}
+   */
+  DevSupportManager create(
+    ReactHostImpl host,
+    Context applicationContext,
+    ReactInstanceDevHelper reactInstanceManagerHelper,
+    @Nullable String packagerPathForJSBundleName,
+    boolean enableOnCreate,
+    @Nullable RedBoxHandler redBoxHandler,
+    @Nullable DevBundleDownloadListener devBundleDownloadListener,
+    int minNumShakes,
+    @Nullable Map<String, RequestHandler> customPackagerCommandHandlers,
+    @Nullable SurfaceDelegateFactory surfaceDelegateFactory,
+    @Nullable DevLoadingViewManager devLoadingViewManager,
+    @Nullable PausedInDebuggerOverlayManager pausedInDebuggerOverlayManager,
+    boolean useDevSupport);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -47,7 +47,9 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.devsupport.DefaultDevSupportManagerFactory;
 import com.facebook.react.devsupport.DevSupportManagerBase;
+import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
 import com.facebook.react.devsupport.inspector.InspectorNetworkHelper;
@@ -106,7 +108,7 @@ public class ReactHostImpl implements ReactHost {
   private final Context mContext;
   private final ReactHostDelegate mReactHostDelegate;
   private final ComponentFactory mComponentFactory;
-  private final DevSupportManager mDevSupportManager;
+  private DevSupportManager mDevSupportManager;
   private final Executor mBGExecutor;
   private final Executor mUIExecutor;
   private final Set<ReactSurfaceImpl> mAttachedSurfaces = new HashSet<>();
@@ -142,29 +144,49 @@ public class ReactHostImpl implements ReactHost {
   private volatile boolean mHostInvalidated = false;
 
   public ReactHostImpl(
-      Context context,
-      ReactHostDelegate delegate,
-      ComponentFactory componentFactory,
-      boolean allowPackagerServerAccess,
-      boolean useDevSupport) {
+    Context context,
+    ReactHostDelegate delegate,
+    ComponentFactory componentFactory,
+    boolean allowPackagerServerAccess,
+    boolean useDevSupport) {
     this(
-        context,
-        delegate,
-        componentFactory,
-        Executors.newSingleThreadExecutor(),
-        Task.UI_THREAD_EXECUTOR,
-        allowPackagerServerAccess,
-        useDevSupport);
+      context,
+      delegate,
+      componentFactory,
+      Executors.newSingleThreadExecutor(),
+      Task.UI_THREAD_EXECUTOR,
+      allowPackagerServerAccess,
+      useDevSupport);
   }
 
   public ReactHostImpl(
-      Context context,
-      ReactHostDelegate delegate,
-      ComponentFactory componentFactory,
-      Executor bgExecutor,
-      Executor uiExecutor,
-      boolean allowPackagerServerAccess,
-      boolean useDevSupport) {
+    Context context,
+    ReactHostDelegate delegate,
+    ComponentFactory componentFactory,
+    Executor bgExecutor,
+    Executor uiExecutor,
+    boolean allowPackagerServerAccess,
+    boolean useDevSupport) {
+    this(
+      context,
+      delegate,
+      componentFactory,
+      bgExecutor,
+      uiExecutor,
+      allowPackagerServerAccess,
+      useDevSupport,
+      null);
+  }
+
+  public ReactHostImpl(
+    Context context,
+    ReactHostDelegate delegate,
+    ComponentFactory componentFactory,
+    Executor bgExecutor,
+    Executor uiExecutor,
+    boolean allowPackagerServerAccess,
+    boolean useDevSupport,
+    @Nullable DevSupportManagerFactory devSupportManagerFactory)  {
     mContext = context;
     mReactHostDelegate = delegate;
     mComponentFactory = componentFactory;
@@ -174,13 +196,26 @@ public class ReactHostImpl implements ReactHost {
     mAllowPackagerServerAccess = allowPackagerServerAccess;
     mUseDevSupport = useDevSupport;
 
-    if (mUseDevSupport) {
-      mDevSupportManager =
-          new BridgelessDevSupportManager(
-              ReactHostImpl.this, mContext, mReactHostDelegate.getJsMainModulePath());
-    } else {
-      mDevSupportManager = new ReleaseDevSupportManager();
+    if (devSupportManagerFactory == null) {
+      devSupportManagerFactory = new DefaultDevSupportManagerFactory();
     }
+
+    mDevSupportManager =
+      devSupportManagerFactory.create(
+        /* reactHost */ ReactHostImpl.this,
+        /* applicationContext */ context.getApplicationContext(),
+        /* reactInstanceManagerHelper */ BridgelessDevSupportManager.createInstanceDevHelper(
+          ReactHostImpl.this),
+        /* packagerPathForJSBundleName */ mReactHostDelegate.getJsMainModulePath(),
+        /* enableOnCreate */ true,
+        /* redBoxHandler */ null,
+        /* devBundleDownloadListener */ null,
+        /* minNumShakes */ 2,
+        /* customPackagerCommandHandlers */ null,
+        /* surfaceDelegateFactory */ null,
+        /* devLoadingViewManager */ null,
+        /* pausedInDebuggerOverlayManager */ null,
+        mUseDevSupport);
   }
 
   @Override


### PR DESCRIPTION
## Summary:
This is the same PR as [here](https://github.com/facebook/react-native/pull/46914). It will unblock us for SDK 52, but Nico plans a larger refactor to remove the ReactHost dependency from the dev support manager. This won't land in 76, so for now, this will work for us.
