### PR TITLE
[0.80] Change type from String? -> String

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
@@ -18,10 +18,10 @@ import java.util.Locale
 
 public object AndroidInfoHelpers {
 
-  public var EMULATOR_LOCALHOST: String? = "10.0.2.2"
-  public var GENYMOTION_LOCALHOST: String? = "10.0.3.2"
+  public var EMULATOR_LOCALHOST: String = "10.0.2.2"
+  public var GENYMOTION_LOCALHOST: String = "10.0.3.2"
   @JvmField
-  public var DEVICE_LOCALHOST: String? = "localhost"
+  public var DEVICE_LOCALHOST: String = "localhost"
   public val METRO_HOST_PROP_NAME: String = "metro.host"
   private val TAG = AndroidInfoHelpers::class.java.simpleName
   private var metroHostPropValue: String? = null


### PR DESCRIPTION
In https://github.com/expo/react-native/commits/416c899952ac1a9294cec07a9c127e58a4c2f6f5/ we added support for overriding DevServerPort and InspectorProxyPort on Android.

This commit updates the above one with correct types for the variables after upgrading to RN 0.80.
