### PR TITLE
[android] Add dev-menu floating action button option

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
@@ -60,12 +60,21 @@ public class DevInternalSettings(applicationContext: Context, private val listen
   override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
     if (listener != null) {
       if (PREFS_FPS_DEBUG_KEY == key ||
-          PREFS_JS_DEV_MODE_DEBUG_KEY == key ||
-          PREFS_JS_MINIFY_DEBUG_KEY == key) {
+        PREFS_JS_DEV_MODE_DEBUG_KEY == key ||
+        PREFS_JS_MINIFY_DEBUG_KEY == key ||
+        PREFS_FLOATING_ACTION_BUTTON_KEY == key
+      ) {
         listener.onInternalSettingsChanged()
       }
     }
   }
+
+  override var isFloatingActionButtonEnabled: Boolean
+    // TODO: @behenate change the default to true for VR
+    get() = preferences.getBoolean(PREFS_FLOATING_ACTION_BUTTON_KEY, false)
+    set(value) {
+      preferences.edit().putBoolean(PREFS_FLOATING_ACTION_BUTTON_KEY, value).apply()
+    }
 
   override var isElementInspectorEnabled: Boolean
     get() = preferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false)
@@ -99,6 +108,7 @@ public class DevInternalSettings(applicationContext: Context, private val listen
     private const val PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug"
     private const val PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug"
     private const val PREFS_HOT_MODULE_REPLACEMENT_KEY = "hot_module_replacement"
+    private const val PREFS_FLOATING_ACTION_BUTTON_KEY = "floating_action_button"
   }
 
 private var exponentActivityId: Int = -1

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -774,6 +774,12 @@ public abstract class DevSupportManagerBase(
     UiThreadUtil.runOnUiThread { devSettings.isFpsDebugEnabled = isFpsDebugEnabled }
   }
 
+  public override fun setFloatingActionButtonEnabled(isFabEnabled: Boolean) {
+    UiThreadUtil.runOnUiThread {
+      devSettings.isFloatingActionButtonEnabled = isFabEnabled
+    }
+  }
+
   override fun toggleElementInspector() {
     if (!isDevSupportEnabled) {
       return

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -66,6 +66,8 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   public override fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean): Unit = Unit
 
+  public override fun setFloatingActionButtonEnabled(isFabEnabled: Boolean): Unit = Unit
+
   public override fun toggleElementInspector(): Unit = Unit
 
   public override var devSupportEnabled: Boolean

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -76,6 +76,8 @@ public interface DevSupportManager : JSExceptionHandler {
 
   public fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean)
 
+  public fun setFloatingActionButtonEnabled(isFabEnabled: Boolean)
+
   public fun toggleElementInspector()
 
   public fun downloadBundleResourceFromUrlSync(resourceURL: String, outputFile: File): File?

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
@@ -29,6 +29,9 @@ public interface DeveloperSettings {
   /** Whether element inspector is enabled. */
   public var isElementInspectorEnabled: Boolean
 
+  /** Whether floating action button is enabled */
+  public var isFloatingActionButtonEnabled: Boolean
+
   /** Whether Nuclide JS debugging is enabled. */
   public var isDeviceDebugEnabled: Boolean
 


### PR DESCRIPTION
## Why

I want to add android FAB support to the legacy dev-menu  implementation.

## How:

I added necessary methods for storing the fab on/off configuration to the DevSupportManager.

## Test Plan:

Tested in Expo Go on a Pixel 8 device