### PR TITLE
Enable hermes debugger on all build variants

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(jsinspector
 )
 target_compile_reactnative_options(jsinspector PRIVATE)
 target_compile_options(jsinspector PRIVATE
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
+        # Expo Go requires debugging on release builds
+        -DREACT_NATIVE_DEBUGGER_ENABLED=1
+        -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+        # $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
+        # $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
 )


### PR DESCRIPTION
# Why

enable debugging on release build
close ENG-17112

# How

enable `REACT_NATIVE_DEBUGGER_ENABLED` and `REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY` on all variants
